### PR TITLE
[Food-refactor] food 의존성 수정

### DIFF
--- a/src/main/kotlin/com/mealfitkotiln/food/adapter/in/web/FoodController.kt
+++ b/src/main/kotlin/com/mealfitkotiln/food/adapter/in/web/FoodController.kt
@@ -1,22 +1,17 @@
 package com.mealfitkotiln.food.adapter.`in`.web
 
-import com.mealfitkotiln.food.application.service.CommandFoodService
 import com.mealfitkotiln.food.application.FoodDtoAssembler
-import com.mealfitkotiln.food.application.service.QueryFoodService
+import com.mealfitkotiln.food.application.port.`in`.CommandFoodUseCase
+import com.mealfitkotiln.food.application.port.`in`.QueryFoodUseCase
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RequestMapping("/api/food")
 @RestController
 internal class FoodController(
-    private val queryFoodService: QueryFoodService,
-    private val commandFoodService: CommandFoodService,
+    private val queryFoodUseCase: QueryFoodUseCase,
+    private val commandFoodUseCase: CommandFoodUseCase,
 ) {
 
     companion object {
@@ -26,7 +21,7 @@ internal class FoodController(
     @PostMapping("/v1")
     fun saveFood(@RequestBody request: FoodSaveRequest): ResponseEntity<String> {
         val requestDto = FoodDtoAssembler.foodSaveRequestDto(request)
-        commandFoodService.saveFood(requestDto)
+        commandFoodUseCase.saveFood(requestDto)
 
         return ResponseEntity.status(HttpStatus.CREATED)
             .body("생성 완료")
@@ -39,7 +34,7 @@ internal class FoodController(
                 @RequestParam(defaultValue = "false") isAsc:Boolean,
                 @RequestParam(defaultValue = DEFAULT_PAGE_SIZE.toString()) pageSize: Int): ResponseEntity<String> {
         val requestDto = FoodDtoAssembler.foodInfoRequestDto(foodName, pageSize, sortKey, isAsc, lastId)
-        queryFoodService.getFoodsByName(requestDto)
+        queryFoodUseCase.getFoodsByName(requestDto)
 
         return ResponseEntity.status(HttpStatus.CREATED)
             .body("생성 완료")

--- a/src/main/kotlin/com/mealfitkotiln/food/adapter/out/persistence/FoodPersistenceAdapter.kt
+++ b/src/main/kotlin/com/mealfitkotiln/food/adapter/out/persistence/FoodPersistenceAdapter.kt
@@ -22,11 +22,15 @@ internal class FoodPersistenceAdapter(
         foodJpaRepository.save(food)
     }
 
+    override fun deleteAll() {
+        foodJpaRepository.deleteAll()
+    }
+
     override fun getFoodsByName(
         foodName: String,
+        size: Int,
         sortKey: String,
         asc: Boolean,
-        size: Int,
         lastId: Long
     ): List<Food> {
         val sort = if (asc) Sort.Direction.ASC else Sort.Direction.DESC

--- a/src/main/kotlin/com/mealfitkotiln/food/application/port/out/CommandFoodPort.kt
+++ b/src/main/kotlin/com/mealfitkotiln/food/application/port/out/CommandFoodPort.kt
@@ -8,5 +8,12 @@ interface CommandFoodPort {
 
     fun updateFood(food: Food)
 
+    /**
+     * @author 9JaHyun
+     * @desc 테스트 도중 원활한 DB 초기화를 위해 deleteAll() 메서드를 추가했습니다.
+     *       클라이언트들에게 제공하는 메서드가 아니기 때문에 주의를 해서 사용해야 합니다.
+     *       현재 임시방편으로 만들어 놓았기 때문에 추후 deprecated 될 수 있습니다.
+     * @since 1.0
+     */
     fun deleteAll()
 }

--- a/src/main/kotlin/com/mealfitkotiln/food/application/port/out/CommandFoodPort.kt
+++ b/src/main/kotlin/com/mealfitkotiln/food/application/port/out/CommandFoodPort.kt
@@ -7,4 +7,6 @@ interface CommandFoodPort {
     fun saveFood(food: Food)
 
     fun updateFood(food: Food)
+
+    fun deleteAll()
 }

--- a/src/main/kotlin/com/mealfitkotiln/food/application/port/out/QueryFoodPort.kt
+++ b/src/main/kotlin/com/mealfitkotiln/food/application/port/out/QueryFoodPort.kt
@@ -6,9 +6,9 @@ interface QueryFoodPort {
 
     fun getFoodsByName(
         foodName: String,
+        size: Int,
         sortKey: String,
         asc: Boolean,
-        size: Int,
         lastId: Long
     ): List<Food>
 

--- a/src/main/kotlin/com/mealfitkotiln/food/application/service/CommandFoodService.kt
+++ b/src/main/kotlin/com/mealfitkotiln/food/application/service/CommandFoodService.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-class CommandFoodService(
+internal class CommandFoodService(
     private val queryFoodPort: QueryFoodPort,
     private val commandFoodPort: CommandFoodPort
 ) : CommandFoodUseCase{
@@ -22,5 +22,9 @@ class CommandFoodService(
 
     override fun updateFood(foodUpdateRequestDto: FoodUpdateRequestDto) {
         TODO("Not yet implemented")
+    }
+
+    fun deleteAll() {
+        commandFoodPort.deleteAll()
     }
 }

--- a/src/main/kotlin/com/mealfitkotiln/food/application/service/QueryFoodService.kt
+++ b/src/main/kotlin/com/mealfitkotiln/food/application/service/QueryFoodService.kt
@@ -7,16 +7,16 @@ import com.mealfitkotiln.food.application.port.out.QueryFoodPort
 import org.springframework.stereotype.Service
 
 @Service
-class QueryFoodService(
+internal class QueryFoodService(
     private val queryFoodPort: QueryFoodPort
 ) : QueryFoodUseCase {
 
     override fun getFoodsByName(foodInfoRequestDto: FoodInfoRequestDto): List<FoodInfoResponse> {
         return queryFoodPort.getFoodsByName(
             foodInfoRequestDto.foodName,
+            foodInfoRequestDto.size,
             foodInfoRequestDto.sortKey,
             foodInfoRequestDto.isAsc,
-            foodInfoRequestDto.size,
             foodInfoRequestDto.lastId
         ).map { food -> FoodInfoResponse(food) }
     }

--- a/src/test/kotlin/com/mealfitkotiln/food/application/service/CommandFoodServiceTest.kt
+++ b/src/test/kotlin/com/mealfitkotiln/food/application/service/CommandFoodServiceTest.kt
@@ -1,7 +1,10 @@
 package com.mealfitkotiln.food.application.service
 
-import com.mealfitkotiln.food.application.port.`in`.FoodSaveRequestDto
+import com.mealfitkotiln.food.application.port.out.CommandFoodPort
+import com.mealfitkotiln.food.application.port.out.QueryFoodPort
+import com.mealfitkotiln.food.domain.Food
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -10,9 +13,14 @@ import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class CommandFoodServiceTest @Autowired constructor(
-    private val commandFoodService: CommandFoodService,
-    private val queryFoodService: QueryFoodService
+    private val commandFoodPort: CommandFoodPort,
+    private val queryFoodPort: QueryFoodPort
 ) {
+
+    @AfterEach
+    fun tearDown() {
+        commandFoodPort.deleteAll()
+    }
 
     @Nested
     @DisplayName("saveFood() 메서드는")
@@ -22,15 +30,15 @@ class CommandFoodServiceTest @Autowired constructor(
         @Test
         fun saveFood_success() {
             // given
-            val requestDto = FoodSaveRequestDto("사과", 100.0,
+            val food = Food("사과", 100.0,
                 80.0, 15.0, 1.0, 1.0, "전국")
 
             // when
-            commandFoodService.saveFood(requestDto)
+            commandFoodPort.saveFood(food)
 
             // then
-            val findResult = queryFoodService.getFoodById(1L)
-            assertThat(findResult.foodId).isEqualTo(1)
+            val findResult = queryFoodPort.getFoodById(1L)
+            assertThat(findResult.id).isEqualTo(1)
             assertThat(findResult.foodName).isEqualTo("사과")
             assertThat(findResult.oneServing).isEqualTo(100.0)
             assertThat(findResult.kcal).isEqualTo(80.0)

--- a/src/test/kotlin/com/mealfitkotiln/food/application/service/QueryFoodServiceTest.kt
+++ b/src/test/kotlin/com/mealfitkotiln/food/application/service/QueryFoodServiceTest.kt
@@ -1,8 +1,10 @@
-성package com.mealfitkotiln.food.application.service
+package com.mealfitkotiln.food.application.service
 
-import com.mealfitkotiln.food.application.port.`in`.FoodInfoRequestDto
-import com.mealfitkotiln.food.application.port.`in`.FoodSaveRequestDto
+import com.mealfitkotiln.food.application.port.out.CommandFoodPort
+import com.mealfitkotiln.food.application.port.out.QueryFoodPort
+import com.mealfitkotiln.food.domain.Food
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -11,9 +13,15 @@ import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class QueryFoodServiceTest @Autowired constructor(
-    private val commandFoodService: CommandFoodService,
-    private val queryFoodService: QueryFoodService
+    private val queryFoodPort: QueryFoodPort,
+    private val commandFoodPort: CommandFoodPort
 ) {
+
+    @AfterEach
+    fun tearDown() {
+        commandFoodPort.deleteAll()
+    }
+
     @Nested
     @DisplayName("findFoods() 메서드는")
     inner class Testing_findFoods {
@@ -22,13 +30,13 @@ class QueryFoodServiceTest @Autowired constructor(
         @Test
         fun findFoods_success() {
             // given
-            commandFoodService.saveFood(FoodSaveRequestDto("음식1", 100.0, 150.0, 30.0, 10.0, 11.0, "제조사1"))
-            commandFoodService.saveFood(FoodSaveRequestDto("음식2", 110.0, 200.0, 35.0, 15.0, 16.0, "제조사2"))
-            commandFoodService.saveFood(FoodSaveRequestDto("음식3", 120.0, 300.0, 40.0, 20.0, 21.0, "제조사3"))
+            commandFoodPort.saveFood(Food("음식1", 100.0, 150.0, 30.0, 10.0, 11.0, "제조사1"))
+            commandFoodPort.saveFood(Food("음식2", 110.0, 200.0, 35.0, 15.0, 16.0, "제조사2"))
+            commandFoodPort.saveFood(Food("음식3", 120.0, 300.0, 40.0, 20.0, 21.0, "제조사3"))
 
             // when
             val findResult =
-                queryFoodService.getFoodsByName(FoodInfoRequestDto("음식", 10, "id", false, 10))
+                queryFoodPort.getFoodsByName("음식", 10, "id", false, 10)
 
             // then
             assertThat(findResult).hasSize(3)
@@ -48,13 +56,13 @@ class QueryFoodServiceTest @Autowired constructor(
         @Test
         fun findFoods_lastId() {
             // given
-            commandFoodService.saveFood(FoodSaveRequestDto("음식1", 100.0, 150.0, 30.0, 10.0, 11.0, "제조사1"))
-            commandFoodService.saveFood(FoodSaveRequestDto("음식2", 110.0, 200.0, 35.0, 15.0, 16.0, "제조사2"))
-            commandFoodService.saveFood(FoodSaveRequestDto("음식3", 120.0, 300.0, 40.0, 20.0, 21.0, "제조사3"))
+            commandFoodPort.saveFood(Food("음식1", 100.0, 150.0, 30.0, 10.0, 11.0, "제조사1"))
+            commandFoodPort.saveFood(Food("음식2", 110.0, 200.0, 35.0, 15.0, 16.0, "제조사2"))
+            commandFoodPort.saveFood(Food("음식3", 120.0, 300.0, 40.0, 20.0, 21.0, "제조사3"))
 
             // when
             val findResult =
-                queryFoodService.getFoodsByName(FoodInfoRequestDto("음식", 2, "id", false, 10))
+                queryFoodPort.getFoodsByName("음식", 2, "id", false, 10)
 
             // then
             assertThat(findResult).hasSize(2)


### PR DESCRIPTION
* Food 도메인의 잘못된 의존성을 수정했습니다.
* 가독성을 위해 메서드 파라미터 순서를 일치시켰습니다.
* 원활한 테스트를 위해 deleteAll() 기능을 추가했습니다.
ISSUE #3 