### PR TITLE
Food refactor - 의존성 재변경

### DIFF
--- a/src/main/kotlin/com/mealfitkotiln/food/application/service/CommandFoodService.kt
+++ b/src/main/kotlin/com/mealfitkotiln/food/application/service/CommandFoodService.kt
@@ -4,13 +4,11 @@ import com.mealfitkotiln.food.application.port.`in`.FoodSaveRequestDto
 import com.mealfitkotiln.food.application.port.`in`.CommandFoodUseCase
 import com.mealfitkotiln.food.application.port.`in`.FoodUpdateRequestDto
 import com.mealfitkotiln.food.application.port.out.CommandFoodPort
-import com.mealfitkotiln.food.application.port.out.QueryFoodPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-internal class CommandFoodService(
-    private val queryFoodPort: QueryFoodPort,
+class CommandFoodService(
     private val commandFoodPort: CommandFoodPort
 ) : CommandFoodUseCase{
 

--- a/src/main/kotlin/com/mealfitkotiln/food/application/service/QueryFoodService.kt
+++ b/src/main/kotlin/com/mealfitkotiln/food/application/service/QueryFoodService.kt
@@ -7,7 +7,7 @@ import com.mealfitkotiln.food.application.port.out.QueryFoodPort
 import org.springframework.stereotype.Service
 
 @Service
-internal class QueryFoodService(
+class QueryFoodService(
     private val queryFoodPort: QueryFoodPort
 ) : QueryFoodUseCase {
 

--- a/src/test/kotlin/com/mealfitkotiln/food/application/service/CommandFoodServiceTest.kt
+++ b/src/test/kotlin/com/mealfitkotiln/food/application/service/CommandFoodServiceTest.kt
@@ -1,8 +1,6 @@
 package com.mealfitkotiln.food.application.service
 
-import com.mealfitkotiln.food.application.port.out.CommandFoodPort
-import com.mealfitkotiln.food.application.port.out.QueryFoodPort
-import com.mealfitkotiln.food.domain.Food
+import com.mealfitkotiln.food.application.port.`in`.FoodSaveRequestDto
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
@@ -13,13 +11,13 @@ import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class CommandFoodServiceTest @Autowired constructor(
-    private val commandFoodPort: CommandFoodPort,
-    private val queryFoodPort: QueryFoodPort
+    private val commandFoodService: CommandFoodService,
+    private val queryFoodService: QueryFoodService,
 ) {
 
     @AfterEach
     fun tearDown() {
-        commandFoodPort.deleteAll()
+        commandFoodService.deleteAll()
     }
 
     @Nested
@@ -29,16 +27,18 @@ class CommandFoodServiceTest @Autowired constructor(
         @DisplayName("FoodSaveRequestDto가 완전히 입력되면 성공")
         @Test
         fun saveFood_success() {
-            // given
-            val food = Food("사과", 100.0,
-                80.0, 15.0, 1.0, 1.0, "전국")
+
+            val requestDto = FoodSaveRequestDto(
+                "사과", 100.0,
+                80.0, 15.0, 1.0, 1.0, "전국"
+            )
 
             // when
-            commandFoodPort.saveFood(food)
+            commandFoodService.saveFood(requestDto)
 
             // then
-            val findResult = queryFoodPort.getFoodById(1L)
-            assertThat(findResult.id).isEqualTo(1)
+            val findResult = queryFoodService.getFoodById(1L)
+            assertThat(findResult.foodId).isEqualTo(1)
             assertThat(findResult.foodName).isEqualTo("사과")
             assertThat(findResult.oneServing).isEqualTo(100.0)
             assertThat(findResult.kcal).isEqualTo(80.0)
@@ -48,6 +48,4 @@ class CommandFoodServiceTest @Autowired constructor(
             assertThat(findResult.madeBy).isEqualTo("전국")
         }
     }
-
-
 }

--- a/src/test/kotlin/com/mealfitkotiln/food/application/service/QueryFoodServiceTest.kt
+++ b/src/test/kotlin/com/mealfitkotiln/food/application/service/QueryFoodServiceTest.kt
@@ -1,8 +1,7 @@
 package com.mealfitkotiln.food.application.service
 
-import com.mealfitkotiln.food.application.port.out.CommandFoodPort
-import com.mealfitkotiln.food.application.port.out.QueryFoodPort
-import com.mealfitkotiln.food.domain.Food
+import com.mealfitkotiln.food.application.port.`in`.FoodInfoRequestDto
+import com.mealfitkotiln.food.application.port.`in`.FoodSaveRequestDto
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
@@ -13,13 +12,13 @@ import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class QueryFoodServiceTest @Autowired constructor(
-    private val queryFoodPort: QueryFoodPort,
-    private val commandFoodPort: CommandFoodPort
+    private val queryFoodService: QueryFoodService,
+    private val commandFoodService: CommandFoodService
 ) {
 
     @AfterEach
     fun tearDown() {
-        commandFoodPort.deleteAll()
+        commandFoodService.deleteAll()
     }
 
     @Nested
@@ -30,13 +29,44 @@ class QueryFoodServiceTest @Autowired constructor(
         @Test
         fun findFoods_success() {
             // given
-            commandFoodPort.saveFood(Food("음식1", 100.0, 150.0, 30.0, 10.0, 11.0, "제조사1"))
-            commandFoodPort.saveFood(Food("음식2", 110.0, 200.0, 35.0, 15.0, 16.0, "제조사2"))
-            commandFoodPort.saveFood(Food("음식3", 120.0, 300.0, 40.0, 20.0, 21.0, "제조사3"))
+            commandFoodService.saveFood(
+                FoodSaveRequestDto(
+                    "음식1",
+                    100.0,
+                    150.0,
+                    30.0,
+                    10.0,
+                    11.0,
+                    "제조사1"
+                )
+            )
+            commandFoodService.saveFood(
+                FoodSaveRequestDto(
+                    "음식2",
+                    110.0,
+                    200.0,
+                    35.0,
+                    15.0,
+                    16.0,
+                    "제조사2"
+                )
+            )
+            commandFoodService.saveFood(
+                FoodSaveRequestDto(
+                    "음식3",
+                    120.0,
+                    300.0,
+                    40.0,
+                    20.0,
+                    21.0,
+                    "제조사3"
+                )
+            )
 
             // when
-            val findResult =
-                queryFoodPort.getFoodsByName("음식", 10, "id", false, 10)
+            val findResult = queryFoodService.getFoodsByName(
+                FoodInfoRequestDto("음식", 10, "id", false, 10)
+            )
 
             // then
             assertThat(findResult).hasSize(3)
@@ -56,23 +86,61 @@ class QueryFoodServiceTest @Autowired constructor(
         @Test
         fun findFoods_lastId() {
             // given
-            commandFoodPort.saveFood(Food("음식1", 100.0, 150.0, 30.0, 10.0, 11.0, "제조사1"))
-            commandFoodPort.saveFood(Food("음식2", 110.0, 200.0, 35.0, 15.0, 16.0, "제조사2"))
-            commandFoodPort.saveFood(Food("음식3", 120.0, 300.0, 40.0, 20.0, 21.0, "제조사3"))
+            commandFoodService.saveFood(
+                FoodSaveRequestDto(
+                    "음식1",
+                    100.0,
+                    150.0,
+                    30.0,
+                    10.0,
+                    11.0,
+                    "제조사1"
+                )
+            )
+            commandFoodService.saveFood(
+                FoodSaveRequestDto(
+                    "음식2",
+                    110.0,
+                    200.0,
+                    35.0,
+                    15.0,
+                    16.0,
+                    "제조사2"
+                )
+            )
+            commandFoodService.saveFood(
+                FoodSaveRequestDto(
+                    "음식3",
+                    120.0,
+                    300.0,
+                    40.0,
+                    20.0,
+                    21.0,
+                    "제조사3"
+                )
+            )
 
             // when
-            val findResult =
-                queryFoodPort.getFoodsByName("음식", 2, "id", false, 10)
+            val findResult = queryFoodService.getFoodsByName(
+                FoodInfoRequestDto("음식", 2, "id", false, 10)
+            )
 
             // then
             assertThat(findResult).hasSize(2)
-            assertThat(findResult).extracting("foodName").containsExactlyInAnyOrder("음식3", "음식2")
-            assertThat(findResult).extracting("oneServing").containsExactlyInAnyOrder(120.0, 110.0)
-            assertThat(findResult).extracting("kcal").containsExactlyInAnyOrder(300.0, 200.0)
-            assertThat(findResult).extracting("carbs").containsExactlyInAnyOrder(40.0, 35.0)
-            assertThat(findResult).extracting("protein").containsExactlyInAnyOrder(20.0, 15.0)
-            assertThat(findResult).extracting("fat").containsExactlyInAnyOrder(21.0, 16.0)
-            assertThat(findResult).extracting("madeBy").containsExactlyInAnyOrder("제조사3", "제조사2")
+            assertThat(findResult).extracting("foodName")
+                .containsExactlyInAnyOrder("음식3", "음식2")
+            assertThat(findResult).extracting("oneServing")
+                .containsExactlyInAnyOrder(120.0, 110.0)
+            assertThat(findResult).extracting("kcal")
+                .containsExactlyInAnyOrder(300.0, 200.0)
+            assertThat(findResult).extracting("carbs")
+                .containsExactlyInAnyOrder(40.0, 35.0)
+            assertThat(findResult).extracting("protein")
+                .containsExactlyInAnyOrder(20.0, 15.0)
+            assertThat(findResult).extracting("fat")
+                .containsExactlyInAnyOrder(21.0, 16.0)
+            assertThat(findResult).extracting("madeBy")
+                .containsExactlyInAnyOrder("제조사3", "제조사2")
         }
     }
 }

--- a/src/test/kotlin/com/mealfitkotiln/user/application/service/CommandUserServiceTest.kt
+++ b/src/test/kotlin/com/mealfitkotiln/user/application/service/CommandUserServiceTest.kt
@@ -1,0 +1,5 @@
+package com.mealfitkotiln.user.application.service
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class CommandUserServiceTest

--- a/src/test/kotlin/com/mealfitkotiln/user/application/service/QueryUserServiceTest.kt
+++ b/src/test/kotlin/com/mealfitkotiln/user/application/service/QueryUserServiceTest.kt
@@ -1,0 +1,42 @@
+package com.mealfitkotiln.user.application.service
+
+import com.mealfitkotiln.user.application.port.`in`.SignUpRequestDto
+import com.mealfitkotiln.user.application.port.out.CommandUserPort
+import com.mealfitkotiln.user.application.port.out.QueryUserPort
+import com.mealfitkotiln.user.domain.ProviderType
+import com.mealfitkotiln.user.domain.User
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+internal class QueryUserServiceTest @Autowired constructor(
+    private val queryUserService: QueryUserService,
+    private val commandUserService: CommandUserService
+) {
+
+    @Nested
+    @DisplayName("findUserById() 테스트는")
+    inner class Testing_findUserById() {
+
+        @DisplayName("해당하는 id가 존재하면 성공한다.")
+        @Test
+        fun findUserById_success() {
+
+            // given
+            commandUserService.signup(SignUpRequestDto("username1", "nickname1", "profileImage1", ProviderType.GOOGLE))
+            commandUserService.signup(SignUpRequestDto("username2", "nickname2", "profileImage2", ProviderType.NAVER))
+            commandUserService.signup(SignUpRequestDto("username3", "nickname3", "profileImage3", ProviderType.KAKAO))
+            commandUserService.signup(SignUpRequestDto("username4", "nickname4", "profileImage4", ProviderType.GOOGLE))
+
+            // when
+            val user1 = queryUserService.findUserById(1)
+
+            // then
+        }
+    }
+}


### PR DESCRIPTION
## Test 의존성 재변경
- 서비스 내부 로직을 테스트하는 것이 아닌 service 메서드 호출시 작동 여부를 테스트 하는 것이기 때문에 굳이 port 의존성을 사용하지 않아도 될 것 같습니다.
- port -> service로 의존성을 재변경 했습니다.
- 이를 위해 internal service를 다시 public으로 재변경 했습니다.
ISSUE #3